### PR TITLE
complement descriptions of deep clone

### DIFF
--- a/JS/JS-br.md
+++ b/JS/JS-br.md
@@ -577,6 +577,7 @@ console.log(b.jobs.first) // FE
 
 But this method also has its limits:
 * ignore `undefined`
+* ignore `symbol`
 * unable to serialize function
 * unable to resolve circular references in an object
 ```js
@@ -600,10 +601,11 @@ If an object is circularly referenced like the above example, you’ll find the 
 
 ![](https://user-gold-cdn.xitu.io/2018/3/28/1626b1ec2d3f9e41?w=840&h=100&f=png&s=30123)
 
-When dealing with function or `undefined`,  the object can also not be serialized properly.
+When dealing with function, `undefined` or `symbol`, the object can also not be serialized properly.
 ```js
 let a = {
     age: undefined,
+    sex: Symbol('male'),
     jobs: function() {},
     name: 'yck'
 }

--- a/JS/JS-ch.md
+++ b/JS/JS-ch.md
@@ -615,6 +615,7 @@ console.log(b.jobs.first) // FE
 但是该方法也是有局限性的：
 
 - 会忽略 `undefined`
+- 会忽略 `symbol`
 - 不能序列化函数
 - 不能解决循环引用的对象
 
@@ -639,11 +640,12 @@ console.log(newObj)
 
 ![](https://user-gold-cdn.xitu.io/2018/3/28/1626b1ec2d3f9e41?w=840&h=100&f=png&s=30123)
 
-在遇到函数或者 `undefined` 的时候，该对象也不能正常的序列化
+在遇到函数、 `undefined` 或者 `symbol` 的时候，该对象也不能正常的序列化
 
 ```js
 let a = {
     age: undefined,
+    sex: Symbol('male'),
     jobs: function() {},
     name: 'yck'
 }

--- a/JS/JS-en.md
+++ b/JS/JS-en.md
@@ -577,6 +577,7 @@ console.log(b.jobs.first) // FE
 
 But this method also has its limits:
 * ignore `undefined`
+* ignore `symbol`
 * unable to serialize function
 * unable to resolve circular references in an object
 ```js
@@ -600,10 +601,11 @@ If an object is circularly referenced like the above example, you’ll find the 
 
 ![](https://user-gold-cdn.xitu.io/2018/3/28/1626b1ec2d3f9e41?w=840&h=100&f=png&s=30123)
 
-When dealing with function or `undefined`,  the object can also not be serialized properly.
+When dealing with function, `undefined` or `symbol`, the object can also not be serialized properly.
 ```js
 let a = {
     age: undefined,
+    sex: Symbol('male'),
     jobs: function() {},
     name: 'yck'
 }


### PR DESCRIPTION
JSON.parse( JSON.stringify() ) 实现深拷贝，除了文中提到的局限性外，还存在忽略 Symbol 的情况。

此 PR 弥补了以上内容的缺失。

以下是 demo code，可以在控制台检测一下：

let a = {
    age: undefined,
    sex: Symbol('male'),
    jobs: function() {},
    name: 'yck'
}
let b = JSON.parse(JSON.stringify(a))
console.log(b)
