### PR TITLE
stopPropagation修正

### DIFF
--- a/Browser/browser-ch.md
+++ b/Browser/browser-ch.md
@@ -60,7 +60,7 @@ node.addEventListener('click',(event) =>{
 - `once`，布尔值，值为 `true` 表示该回调只会调用一次，调用后会移除监听
 - `passive`，布尔值，表示永远不会调用 `preventDefault` 
 
-一般来说，我们只希望事件只触发在目标上，这时候可以使用 `stopPropagation` 来阻止事件的进一步传播。通常我们认为 `stopPropagation` 是用来阻止事件冒泡的，其实该函数也可以阻止捕获事件。`stopImmediatePropagation` 同样也能实现阻止事件，但是还能阻止该事件目标执行别的注册事件。
+一般来说，我们只希望事件只触发在目标上，这时候可以使用 `stopPropagation` 来阻止事件的进一步传播。`stopImmediatePropagation` 同样也能实现阻止事件冒泡，但是还能阻止该事件目标执行同类型注册事件。目标对象存在冒泡事件和捕获事件，执行顺序由注册顺序决定
 
 ```js
 node.addEventListener('click',(event) =>{


### PR DESCRIPTION
stopPropagation方法其实并不能阻止对象上的捕获事件，示例中其实是stopImmediatePropagation阻止了后续同类型事件