### PR TITLE
fix:quick-sort-code-mistakes

### DIFF
--- a/Algorithm/algorithm-ch.md
+++ b/Algorithm/algorithm-ch.md
@@ -292,9 +292,9 @@ function sort(array) {
 
 function quickSort(array, left, right) {
   if (left < right) {
-    swap(array, , right)
+    swap(array, parseInt(Math.random() * (right - left + 1)) + left, right)
     // 随机取值，然后和末尾交换，这样做比固定取一个位置的复杂度略低
-    let indexs = part(array, parseInt(Math.random() * (right - left + 1)) + left, right);
+    let indexs = part(array, left, right);
     quickSort(array, left, indexs[0]);
     quickSort(array, indexs[1] + 1, right);
   }
@@ -305,6 +305,7 @@ function part(array, left, right) {
   while (left < more) {
     if (array[left] < array[right]) {
       // 当前值比基准值小，`less` 和 `left` 都加一
+	less + 1 !== left && swap(array, less + 1, left);
 	   ++less;
        ++left;
     } else if (array[left] > array[right]) {


### PR DESCRIPTION
首先原来的295行是少了个参数的。那按照我的理解，这里应该是将随机位置元素交换到最右边。
然后重新把改过的代码运行发现sort([4,3,5,5,4,5])是会得到[3,4,5,5,4,5]的，那按照我的理解，应该需要加上308行这样，去交换小于基准值和等于基准值两者的位置。